### PR TITLE
switch yarnpkg- for nodejs rpm prefix nodejs-

### DIFF
--- a/gen_yarn.py
+++ b/gen_yarn.py
@@ -29,6 +29,5 @@ for line in sys.stdin:
     u = urlparse(str(t[1]).replace('"',''))
     p = u.path.split('/')
     pkg = p[len(p)-1]
-    h = u.netloc.split('.')
-    host = h[len(h)-2]
-    print('quay:' + tag + ':quay/' + host + '-' + pkg)
+    prefix = 'nodejs'
+    print('quay:' + tag + ':quay/' + prefix + '-' + pkg)


### PR DESCRIPTION
In order to match the rest of the product manifest files it would be better if we had the yarnpkg dependencies looking like rpm nodejs dependencies.